### PR TITLE
189 recipe ingredientlist does not update without restarting serverpy

### DIFF
--- a/backend/ingredients/queries.py
+++ b/backend/ingredients/queries.py
@@ -14,15 +14,15 @@ from local_db.orm import User, Ingredient, Recipe, RecipeHasIngredient, RecipeHa
 # Bruk .<kolonnenavn> på retur for å få ut verdier  #
 #####################################################
 
-session = loadSession()
-
 
 def insert_to_ingredients(name: str):
+    session = loadSession()
     ingredient = Ingredient(ingredientName=name)
     session.add(ingredient)
     session.commit()
 
 def insert_to_usergroup_has_ingredient(userGroup, ingredient, price, unit):
+    session = loadSession()
     new_userGroupIngredient = UsergroupHasIngredient(userGroup_iduserGroup=userGroup,
                                                      ingredient_idingredient=ingredient, price=price, unit=unit)
     session.add(new_userGroupIngredient)
@@ -30,26 +30,31 @@ def insert_to_usergroup_has_ingredient(userGroup, ingredient, price, unit):
 
 
 def fetch_ingredients_from_all_user_groups_where_ingredient_name_equals(ingredient) -> Ingredient:
+    session = loadSession()
     return session.query(Ingredient).where(Ingredient.ingredientName == ingredient).first()
 
 
 def fetch_all_ingredients_from_all_usergroups() -> list:
+    session = loadSession()
     return session.query(Ingredient).all()
 
 
 def fetch_ingredients_from_all_usergroups_where_name_is(name):
+    session = loadSession()
     return session.query(Ingredient.idingredient).where(Ingredient.ingredientName == name).first()
 
 
 
 
 def fetch_ingredients_where_usergroup_and_ingredientName_equals(usergroup_id, ingredient_name):
+    session = loadSession()
     return session.query(Ingredient, UsergroupHasIngredient).join(UsergroupHasIngredient, and_(
         Ingredient.idingredient == UsergroupHasIngredient.ingredient_idingredient,
         Ingredient.ingredientName == ingredient_name,
         UsergroupHasIngredient.userGroup_iduserGroup == usergroup_id)).scalar()
 
 def fetch_all_ingredients_where_usergroup_equals(usergroup_id):
+    session = loadSession()
     return session.query(Ingredient, UsergroupHasIngredient).join(UsergroupHasIngredient, and_(
         Ingredient.idingredient == UsergroupHasIngredient.ingredient_idingredient,
         UsergroupHasIngredient.userGroup_iduserGroup == usergroup_id)).all()
@@ -61,6 +66,7 @@ def fetch_all_ingredients_where_usergroup_equals(usergroup_id):
 
 
 def fetch_ingredients_where_usergroup_and_unit_equals(usergroup_id: int, unit: str):
+    session = loadSession()
     return session.query(Ingredient).join(UsergroupHasIngredient,
                                           and_(UsergroupHasIngredient.userGroup_iduserGroup == usergroup_id,
                                                Ingredient.idingredient == UsergroupHasIngredient.ingredient_idingredient,
@@ -68,6 +74,7 @@ def fetch_ingredients_where_usergroup_and_unit_equals(usergroup_id: int, unit: s
 
 
 def fetch_ingredients_in_usergroup_where_price_equals(usergroup_id, price: int):
+    session = loadSession()
     return session.query(Ingredient).join(UsergroupHasIngredient,
                                           and_(UsergroupHasIngredient.userGroup_iduserGroup == usergroup_id,
                                                Ingredient.idingredient == UsergroupHasIngredient.ingredient_idingredient,
@@ -75,6 +82,7 @@ def fetch_ingredients_in_usergroup_where_price_equals(usergroup_id, price: int):
 
 
 def fetch_ingredients_where_price_is_greater_than(usergroup_id, price):
+    session = loadSession()
     return session.query(Ingredient).join(UsergroupHasIngredient,
                                           and_(UsergroupHasIngredient.userGroup_iduserGroup == usergroup_id,
                                                Ingredient.idingredient == UsergroupHasIngredient.ingredient_idingredient,
@@ -82,6 +90,7 @@ def fetch_ingredients_where_price_is_greater_than(usergroup_id, price):
 
 
 def fetch_ingredients_where_price_is_less_than(usergroup_id, price):
+    session = loadSession()
     return session.query(Ingredient).join(UsergroupHasIngredient,
                                           and_(UsergroupHasIngredient.userGroup_iduserGroup == usergroup_id,
                                                Ingredient.idingredient == UsergroupHasIngredient.ingredient_idingredient,
@@ -89,6 +98,7 @@ def fetch_ingredients_where_price_is_less_than(usergroup_id, price):
 
 
 def fetch_ingredients_where_quantity_and_groupid_equals(usergroup_id, quantity: int):
+    session = loadSession()
     return session.query(Ingredient).join(UsergroupHasIngredient,
                                           and_(UsergroupHasIngredient.userGroup_iduserGroup == usergroup_id,
                                                Ingredient.idingredient == UsergroupHasIngredient.ingredient_idingredient,
@@ -96,6 +106,7 @@ def fetch_ingredients_where_quantity_and_groupid_equals(usergroup_id, quantity: 
 
 
 def fetch_ingredients_where_group_id_equals_and_quantity_less_than(usergroup_id, quantity: int):
+    session = loadSession()
     return session.query(Ingredient).join(UsergroupHasIngredient,
                                           and_(UsergroupHasIngredient.userGroup_iduserGroup == usergroup_id,
                                                Ingredient.idingredient == UsergroupHasIngredient.ingredient_idingredient,
@@ -103,6 +114,7 @@ def fetch_ingredients_where_group_id_equals_and_quantity_less_than(usergroup_id,
 
 
 def fetch_ingredients_where_group_id_equals_and_quantity_greater_than(usergroup_id, quantity: int):
+    session = loadSession()
     return session.query(Ingredient).join(UsergroupHasIngredient,
                                           and_(UsergroupHasIngredient.userGroup_iduserGroup == usergroup_id,
                                                Ingredient.idingredient == UsergroupHasIngredient.ingredient_idingredient,
@@ -111,6 +123,7 @@ def fetch_ingredients_where_group_id_equals_and_quantity_greater_than(usergroup_
 
 # TODO: IKKE OK  NOEN SOM KAN REGEX? :(((((
 def fetch_ingredients_where_name_contains_and_group_equals(usergroup_id: int, name: str, ):
+    session = loadSession()
     return session.query(Ingredient).join(UsergroupHasIngredient,
                                           and_(UsergroupHasIngredient.userGroup_iduserGroup == usergroup_id,
                                                Ingredient.idingredient == UsergroupHasIngredient.ingredient_idingredient,
@@ -119,6 +132,7 @@ def fetch_ingredients_where_name_contains_and_group_equals(usergroup_id: int, na
 
 
 def fetch_all_ingredients_where_recipeID_equals(recipe_id, group):
+    session = loadSession()
     return session.query(RecipeHasIngredient.quantity, Ingredient.ingredientName, UsergroupHasIngredient.price, UsergroupHasIngredient.unit, RecipeHasIngredient.ingredient_idingredient)\
         .join(Ingredient, RecipeHasIngredient.ingredient_idingredient == Ingredient.idingredient)\
         .join(UsergroupHasIngredient, RecipeHasIngredient.ingredient_idingredient == UsergroupHasIngredient.ingredient_idingredient)\
@@ -128,6 +142,7 @@ def fetch_all_ingredients_where_recipeID_equals(recipe_id, group):
 
 
 def editIngredientInRecipe(recipeID,ingredient_id,value):
+    session = loadSession()
     field = session.query(RecipeHasIngredient).filter(
         and_(RecipeHasIngredient.recipe_idRecipe == recipeID, RecipeHasIngredient.ingredient_idingredient == ingredient_id)).first()
     field.quantity = value

--- a/backend/ingredients/queries.py
+++ b/backend/ingredients/queries.py
@@ -20,6 +20,7 @@ def insert_to_ingredients(name: str):
     ingredient = Ingredient(ingredientName=name)
     session.add(ingredient)
     session.commit()
+    session.close()
 
 def insert_to_usergroup_has_ingredient(userGroup, ingredient, price, unit):
     session = loadSession()
@@ -27,37 +28,44 @@ def insert_to_usergroup_has_ingredient(userGroup, ingredient, price, unit):
                                                      ingredient_idingredient=ingredient, price=price, unit=unit)
     session.add(new_userGroupIngredient)
     session.commit()
+    session.close()
 
 
 def fetch_ingredients_from_all_user_groups_where_ingredient_name_equals(ingredient) -> Ingredient:
     session = loadSession()
-    return session.query(Ingredient).where(Ingredient.ingredientName == ingredient).first()
-
+    res = session.query(Ingredient).where(Ingredient.ingredientName == ingredient).first()
+    session.close()
+    return res
 
 def fetch_all_ingredients_from_all_usergroups() -> list:
     session = loadSession()
-    return session.query(Ingredient).all()
-
+    res = session.query(Ingredient).all()
+    session.close()
+    return res
 
 def fetch_ingredients_from_all_usergroups_where_name_is(name):
     session = loadSession()
-    return session.query(Ingredient.idingredient).where(Ingredient.ingredientName == name).first()
-
-
+    res = session.query(Ingredient.idingredient).where(Ingredient.ingredientName == name).first()
+    session.close()
+    return res
 
 
 def fetch_ingredients_where_usergroup_and_ingredientName_equals(usergroup_id, ingredient_name):
     session = loadSession()
-    return session.query(Ingredient, UsergroupHasIngredient).join(UsergroupHasIngredient, and_(
+    res = session.query(Ingredient, UsergroupHasIngredient).join(UsergroupHasIngredient, and_(
         Ingredient.idingredient == UsergroupHasIngredient.ingredient_idingredient,
         Ingredient.ingredientName == ingredient_name,
         UsergroupHasIngredient.userGroup_iduserGroup == usergroup_id)).scalar()
+    session.close()
+    return  res
 
 def fetch_all_ingredients_where_usergroup_equals(usergroup_id):
     session = loadSession()
-    return session.query(Ingredient, UsergroupHasIngredient).join(UsergroupHasIngredient, and_(
+    res = session.query(Ingredient, UsergroupHasIngredient).join(UsergroupHasIngredient, and_(
         Ingredient.idingredient == UsergroupHasIngredient.ingredient_idingredient,
         UsergroupHasIngredient.userGroup_iduserGroup == usergroup_id)).all()
+    session.close()
+    return res
 
     # if __name__ == '__main__':
     #     ingredienser = fetch_all_ingredients_where_usergroup_equals(1)
@@ -67,77 +75,95 @@ def fetch_all_ingredients_where_usergroup_equals(usergroup_id):
 
 def fetch_ingredients_where_usergroup_and_unit_equals(usergroup_id: int, unit: str):
     session = loadSession()
-    return session.query(Ingredient).join(UsergroupHasIngredient,
+    res = session.query(Ingredient).join(UsergroupHasIngredient,
                                           and_(UsergroupHasIngredient.userGroup_iduserGroup == usergroup_id,
                                                Ingredient.idingredient == UsergroupHasIngredient.ingredient_idingredient,
                                                UsergroupHasIngredient.unit == unit))
+    session.close()
+    return res
 
 
 def fetch_ingredients_in_usergroup_where_price_equals(usergroup_id, price: int):
     session = loadSession()
-    return session.query(Ingredient).join(UsergroupHasIngredient,
+    res = session.query(Ingredient).join(UsergroupHasIngredient,
                                           and_(UsergroupHasIngredient.userGroup_iduserGroup == usergroup_id,
                                                Ingredient.idingredient == UsergroupHasIngredient.ingredient_idingredient,
                                                UsergroupHasIngredient.price == price))
+    session.close()
+    return res
 
 
 def fetch_ingredients_where_price_is_greater_than(usergroup_id, price):
     session = loadSession()
-    return session.query(Ingredient).join(UsergroupHasIngredient,
+    res = session.query(Ingredient).join(UsergroupHasIngredient,
                                           and_(UsergroupHasIngredient.userGroup_iduserGroup == usergroup_id,
                                                Ingredient.idingredient == UsergroupHasIngredient.ingredient_idingredient,
                                                UsergroupHasIngredient.price > price))
+    session.close()
+    return res
 
 
 def fetch_ingredients_where_price_is_less_than(usergroup_id, price):
     session = loadSession()
-    return session.query(Ingredient).join(UsergroupHasIngredient,
+    res = session.query(Ingredient).join(UsergroupHasIngredient,
                                           and_(UsergroupHasIngredient.userGroup_iduserGroup == usergroup_id,
                                                Ingredient.idingredient == UsergroupHasIngredient.ingredient_idingredient,
                                                UsergroupHasIngredient.price < price))
+    session.close()
+    return res
 
 
 def fetch_ingredients_where_quantity_and_groupid_equals(usergroup_id, quantity: int):
     session = loadSession()
-    return session.query(Ingredient).join(UsergroupHasIngredient,
+    res = session.query(Ingredient).join(UsergroupHasIngredient,
                                           and_(UsergroupHasIngredient.userGroup_iduserGroup == usergroup_id,
                                                Ingredient.idingredient == UsergroupHasIngredient.ingredient_idingredient,
                                                UsergroupHasIngredient.quantity == quantity))
+    session.close()
+    return res
 
 
 def fetch_ingredients_where_group_id_equals_and_quantity_less_than(usergroup_id, quantity: int):
     session = loadSession()
-    return session.query(Ingredient).join(UsergroupHasIngredient,
+    res = session.query(Ingredient).join(UsergroupHasIngredient,
                                           and_(UsergroupHasIngredient.userGroup_iduserGroup == usergroup_id,
                                                Ingredient.idingredient == UsergroupHasIngredient.ingredient_idingredient,
                                                UsergroupHasIngredient.quantity < quantity))
+    session.close()
+    return res
 
 
 def fetch_ingredients_where_group_id_equals_and_quantity_greater_than(usergroup_id, quantity: int):
     session = loadSession()
-    return session.query(Ingredient).join(UsergroupHasIngredient,
+    res = session.query(Ingredient).join(UsergroupHasIngredient,
                                           and_(UsergroupHasIngredient.userGroup_iduserGroup == usergroup_id,
                                                Ingredient.idingredient == UsergroupHasIngredient.ingredient_idingredient,
                                                UsergroupHasIngredient.quantity > quantity))
+    session.close()
+    return res
 
 
 # TODO: IKKE OK  NOEN SOM KAN REGEX? :(((((
 def fetch_ingredients_where_name_contains_and_group_equals(usergroup_id: int, name: str, ):
     session = loadSession()
-    return session.query(Ingredient).join(UsergroupHasIngredient,
+    res = session.query(Ingredient).join(UsergroupHasIngredient,
                                           and_(UsergroupHasIngredient.userGroup_iduserGroup == usergroup_id,
                                                Ingredient.idingredient == UsergroupHasIngredient.ingredient_idingredient,
                                                Ingredient.name == "REGEX"))  # REGEX HER?
+    session.close()
+    return res
 
 
 
 def fetch_all_ingredients_where_recipeID_equals(recipe_id, group):
     session = loadSession()
-    return session.query(RecipeHasIngredient.quantity, Ingredient.ingredientName, UsergroupHasIngredient.price, UsergroupHasIngredient.unit, RecipeHasIngredient.ingredient_idingredient)\
+    res = session.query(RecipeHasIngredient.quantity, Ingredient.ingredientName, UsergroupHasIngredient.price, UsergroupHasIngredient.unit, RecipeHasIngredient.ingredient_idingredient)\
         .join(Ingredient, RecipeHasIngredient.ingredient_idingredient == Ingredient.idingredient)\
         .join(UsergroupHasIngredient, RecipeHasIngredient.ingredient_idingredient == UsergroupHasIngredient.ingredient_idingredient)\
         .filter(RecipeHasIngredient.recipe_idRecipe == recipe_id, UsergroupHasIngredient.userGroup_iduserGroup == group)\
         .all()
+    session.close()
+    return res
 
 
 
@@ -147,5 +173,6 @@ def editIngredientInRecipe(recipeID,ingredient_id,value):
         and_(RecipeHasIngredient.recipe_idRecipe == recipeID, RecipeHasIngredient.ingredient_idingredient == ingredient_id)).first()
     field.quantity = value
     session.commit()
+    session.close()
 
 

--- a/backend/recipes/queries.py
+++ b/backend/recipes/queries.py
@@ -4,54 +4,68 @@ from local_db.orm import User, Ingredient, Recipe, RecipeHasIngredient, RecipeHa
     Usertype, Usergroup, UsergroupHasIngredient, WeeklyMenu, Base, UserHasUsergroup
 from sqlalchemy import *
 
-session = loadSession()
-
 
 # Add default values to recipe availability
 def insert_to_recipeavalilability():
+    session = loadSession()
     avail1 = RecipeAvailability(avilableFor="All")
     avail2 = RecipeAvailability(avilableFor="Group")
     avail3 = RecipeAvailability(avilableFor="User")
     session.add_all([avail1, avail2, avail3])
     session.commit()
+    session.close()
 
 
 # Add recipe
 def insert_to_recipe(name, shortDescription, description, image, userGroup, recipeAvailability, weeklymenu):
+    session = loadSession()
     new_recipe = Recipe(name=name, shortDescription=shortDescription, description=description, image=image,
                         userGroup_iduserGroup=userGroup, recipeAvailability_idrecipeAvailability=recipeAvailability,
                         weeklyMenu_idweeklyMenu=weeklymenu)
     session.add(new_recipe)
     session.commit()
+    session.close()
 
 
 def fetch_recipe_where_recipeId_equals(recipeId):
+    session = loadSession()
+    session.close()
     return session.query(Recipe).where(Recipe.idRecipe == recipeId).first()
 
 def fetch_recipeID_where_name_equals(name):
+    session = loadSession()
+    session.close()
     return session.query(Recipe.idRecipe).where(Recipe.name == name).first()
 
 # Add to recipe_has_ingredient
 def insert_to_recipe_has_ingredient(recipe, ingredient, quantity):
+    session = loadSession()
     new_recipeIngredient = RecipeHasIngredient(recipe_idRecipe=recipe, ingredient_idingredient=ingredient,
                                                quantity=quantity)
     session.add(new_recipeIngredient)
     session.commit()
+    session.close()
 
 
 # Add to recipe_has_weeklyMenu
 def insert_to_recipe_has_weeklymenu(recipe, year, week, expectedConsumption, actualConsumption):
+    session = loadSession()
     new_recipeWeeklymenu = RecipeHasWeeklyMenu(recipe_idRecipe=recipe, weeklyMenu_year=year, weeklyMenu_weekNum=week,
                                                expectedConsumption=expectedConsumption,
                                                actualConsumption=actualConsumption)
     session.add(new_recipeWeeklymenu)
     session.commit()
+    session.close()
 
 
 def fetch_all_recipes():
+    session = loadSession()
+    session.close()
     return session.query(Recipe).all()
 
 def fetch_all_recipes_to_group(group_id):
+    session = loadSession()
+    session.close()
     return session.query(Recipe).where(Recipe.userGroup_iduserGroup == group_id).all()
 
 
@@ -61,5 +75,6 @@ def remove_from_recipe_has_ingredient(recipeID, ingredient_id):
         and_(RecipeHasIngredient.recipe_idRecipe == recipeID, RecipeHasIngredient.ingredient_idingredient == ingredient_id)).delete(
         synchronize_session=False)
     session.commit()
+    session.close()
 
 

--- a/backend/recipes/queries.py
+++ b/backend/recipes/queries.py
@@ -29,13 +29,15 @@ def insert_to_recipe(name, shortDescription, description, image, userGroup, reci
 
 def fetch_recipe_where_recipeId_equals(recipeId):
     session = loadSession()
+    res = session.query(Recipe).where(Recipe.idRecipe == recipeId).first()
     session.close()
-    return session.query(Recipe).where(Recipe.idRecipe == recipeId).first()
+    return res
 
 def fetch_recipeID_where_name_equals(name):
     session = loadSession()
+    res = session.query(Recipe.idRecipe).where(Recipe.name == name).first()
     session.close()
-    return session.query(Recipe.idRecipe).where(Recipe.name == name).first()
+    return res
 
 # Add to recipe_has_ingredient
 def insert_to_recipe_has_ingredient(recipe, ingredient, quantity):
@@ -60,13 +62,15 @@ def insert_to_recipe_has_weeklymenu(recipe, year, week, expectedConsumption, act
 
 def fetch_all_recipes():
     session = loadSession()
+    res = session.query(Recipe).all()
     session.close()
-    return session.query(Recipe).all()
+    return res
 
 def fetch_all_recipes_to_group(group_id):
     session = loadSession()
+    res = session.query(Recipe).where(Recipe.userGroup_iduserGroup == group_id).all()
     session.close()
-    return session.query(Recipe).where(Recipe.userGroup_iduserGroup == group_id).all()
+    return res
 
 
 def remove_from_recipe_has_ingredient(recipeID, ingredient_id):

--- a/backend/recipes/views.py
+++ b/backend/recipes/views.py
@@ -48,7 +48,7 @@ def removeFromRecipeHasIngrediens(recipe_id: int, ingrediens_id: int):
     #fetch_recipe_where_recipeId_equals
     remove_from_recipe_has_ingredient(recipe_id, ingrediens_id)
 
-    return redirect('/oppskrifter')
+    return redirect('/oppskrift/'+ str(recipe_id))
 
 
 @recipes.route('/oppskrift/<recipe_id>/<ingrediens_id>/<value>/update', methods=["GET", "POST"])


### PR DESCRIPTION
session = loadSession() er flyttet tilbake under hver def (spørring). Når den ligger utenfor så oppdateres ikke resultatet av spørringene. Om dette er optimal måte å gjøre det på vet jeg ikke, men det funker.

Har kun gjort endringer i queries.py til recipes og ingredients. Bør også gjøres i weekly menu og auth.

Spørring lagres som objekt, session lukkes ved session.close() og så returnere objekt.
Ved insert, session.close() etter session.commit()

Eks:

def fetch_recipe_where_recipeId_equals(recipeId):
    session = loadSession()
    res = session.query(Recipe).where(Recipe.idRecipe == recipeId).first()
    session.close()
    return res